### PR TITLE
CODEOWNERS + PR Auto-assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @DaleStudy/leetcode-website

--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -1,0 +1,13 @@
+name: 🤖 Automation
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: toshimaru/auto-author-assign@v2.1.0


### PR DESCRIPTION
자동으로 PR에 코드 작성자가 할당되도록 GitHub Actions 워크플로우를 추가합니다.