### PR TITLE
fix: Add missing simple style code to comply with figma

### DIFF
--- a/components/step.js
+++ b/components/step.js
@@ -32,9 +32,14 @@ class StepList extends BaseStepElement {
         row-gap: 10px;
         margin-top: 20px;
 
+        @media only screen and (min-width: 768px) {
+          margin-top: 30px;
+        }
+
         @media only screen and (min-width: 1024px) {
           flex-direction: row;
           column-gap: 10px;
+          margin-top: 40px;
         }
       }
       .step-list ::slotted(ds-step) {
@@ -94,6 +99,7 @@ class Step extends BaseStepElement {
       .step-title h3 {
         font-size: 24px;
         font-weight: var(--font-weight-medium);
+
         @media only screen and (min-width: 768px) {
           font-size: 36px;
         }
@@ -102,6 +108,7 @@ class Step extends BaseStepElement {
         width: auto;
         height: 40px;
         margin: 20px 0;
+
         @media only screen and (min-width: 768px) {
           width: 60px;
           height: 60px;
@@ -112,6 +119,7 @@ class Step extends BaseStepElement {
         font-size: 16px;
         font-weight: var(--font-weight-regular);
         word-break: keep-all;
+
         @media only screen and (min-width: 768px) {
           font-size: 24px;
         }


### PR DESCRIPTION
각 스크린 사이즈에 따른, '스터디 참여방법' 타이틀과 'step-list'간의 간격을 기존 사이즈에만 적용해두고, 태블릿, 데스크톱일 때는 적용해두지 않아서 추가합니다.
<img width="1046" alt="Screenshot 2024-07-10 at 16 23 40" src="https://github.com/DaleStudy/leetcode-website/assets/38199103/38780406-5b32-4a45-81dc-f2e1de0a69f2">



## Checklist before merging

- [x] Link an issue with the pull request
- [x] Ensure no errors or warnings on the browser console
- [ ] Avoid additional major pushes after approval (if necessary, request a new review)
