### PR TITLE
fix: layout with responsive design up to 768px of participant review section and step section

### DIFF
--- a/components/participant-review-section.js
+++ b/components/participant-review-section.js
@@ -18,6 +18,11 @@ class ParticipantReviewsSection extends HTMLElement {
         margin: 0 27px;
         padding: 100px 0;
 
+        @media only screen and (min-width: 768px) {
+          width: 80%;
+          margin: 0 auto;
+        }
+
         @media only screen and (min-width: 1024px) {
           padding: 149px 0;
         }

--- a/components/step-section.js
+++ b/components/step-section.js
@@ -17,6 +17,12 @@ class StepsSection extends HTMLElement {
         max-width: 1550px;
         margin: 0 27px;
         padding: 100px 0;
+
+        @media only screen and (min-width: 768px) {
+          width: 80%;
+          margin: 0 auto;
+        }
+
         @media only screen and (min-width: 1024px) {
           padding: 149px 0;
         }


### PR DESCRIPTION
768px 이후로는 해당 layout(participant-reveiw-section, step-section)들이 다시 80%가 되어야하는데, 링크된 pr들에서 모바일에서는 양쪽 마진을 추가하는 layout으로 수정하며 지금 pr작업을 별도로 해주지 않아서 추가 pr을 올립니다.

## Checklist before merging

- [x] Link an issue with the pull request
- [x] Ensure no errors or warnings on the browser console
- [x] Avoid additional major pushes after approval (if necessary, request a new review)
