### PR TITLE
fix: wrong discord link in intro and code review section

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
         slot="button"
         size="big"
         variant="primary"
-        href="https://discord.gg/43UkheRV"
+        href="https://discord.gg/6TwzdnW6ze"
       >
         디스코드 참여하기
       </ds-button-link>
@@ -111,7 +111,7 @@
         slot="button"
         size="big"
         variant="primary"
-        href="https://discord.gg/43UkheRV"
+        href="https://discord.gg/6TwzdnW6ze"
       >
         디스코드 참여하기
       </ds-button-link>


### PR DESCRIPTION
이슈 리스트 중, 잘못된 디스코드 링크가 삽입되어있는 버그는 빠르게 수정되면 좋을 것 같아 반영합니다.

## Checklist before merging

- [x] Link an issue with the pull request
- [x] Ensure no errors or warnings on the browser console
- [ ] Avoid additional major pushes after approval (if necessary, request a new review)
