### PR TITLE
Fixed incorrect aspect ratio issue with object-fit

### DIFF
--- a/components/image.js
+++ b/components/image.js
@@ -27,6 +27,7 @@ class Image extends HTMLElement {
     return css`
       img {
         display: block;
+        object-fit: contain;
         box-shadow: 2px 2px 4px 0 var(--bg-300);
       }
     `;

--- a/components/step.js
+++ b/components/step.js
@@ -109,7 +109,6 @@ class Step extends BaseStepElement {
           width: 60px;
           height: 60px;
           margin: 50px 0;
-          object-fit: contain;
         }
       }
       .step-content {

--- a/components/step.js
+++ b/components/step.js
@@ -103,11 +103,13 @@ class Step extends BaseStepElement {
         width: auto;
         height: 40px;
         margin: 20px 0;
+        object-fit: contain;
 
         @media only screen and (min-width: 768px) {
           width: 60px;
           height: 60px;
           margin: 50px 0;
+          object-fit: contain;
         }
       }
       .step-content {


### PR DESCRIPTION
<!--
Describe your changes in detail using screenshots, videos, or other supporting materials. Keep in mind that pull requests serve not only to merge your code but also as valuable technical documentation and learning resources for the current and future team members.
-->

## Checklist before merging

- [x] Link an issue with the pull request
- [x] Ensure no errors or warnings on the browser console
- [ ] Avoid additional major pushes after approval (if necessary, request a new review)

이슈가 발생하는 이미지 태그에 ```object-fit: contain;``` 속성을 추가하여 해결

![image](https://github.com/user-attachments/assets/7fbfe165-2829-4c93-920d-5f9eb270f978)
