### PR TITLE
Footer 안 스터디 신청 URL 정정

### DIFF
--- a/components/footer-link-list.js
+++ b/components/footer-link-list.js
@@ -1,4 +1,5 @@
 import { css, html } from "../html-css-utils.js";
+import { APPLICATION_URL } from "../data.js";
 
 class FooterLinkList extends HTMLElement {
   constructor() {
@@ -79,7 +80,7 @@ class FooterLinkList extends HTMLElement {
 
       <li>
         <a
-          href="https://github.com/DaleStudy/leetcode-study/discussions/52"
+          href="${APPLICATION_URL}"
           target="_blank"
           aria-label="Apply for Algorithm study group participation"
         >

--- a/components/step-section.js
+++ b/components/step-section.js
@@ -1,4 +1,5 @@
 import { html, css } from "../html-css-utils.js";
+import { APPLICATION_URL } from "../data.js";
 
 class StepsSection extends HTMLElement {
   constructor() {
@@ -38,7 +39,41 @@ class StepsSection extends HTMLElement {
   createHtml() {
     return html`
       <section>
-        <slot></slot>
+        <ds-hero>스터디 참여방법</ds-hero>
+        <ds-step-list>
+          <ds-step step="1" icon-src="images/icon_step1.png">
+            <p slot="content">
+              현재 스터디 1기(2024년 4/21~8/10)가 진행중이에요. 8/11에 시작하는
+              다음 기수 스터디 참여를 원한다면
+              <ds-step-text-link link="${APPLICATION_URL}">
+                여기
+              </ds-step-text-link>
+              에서 신청할 수 있어요.
+            </p>
+          </ds-step>
+          <ds-step step="2" icon-src="images/icon_step2.png">
+            <p slot="content">
+              답안 제출과 확인은 깃허브를 통해 이루어져요. 스터디 전체
+              진행상황을 알고 싶다면
+              <ds-step-text-link
+                link="https://github.com/orgs/DaleStudy/projects/1"
+              >
+                프로젝트 보드
+              </ds-step-text-link>
+              를 통해 파악할 수 있어요.
+            </p>
+          </ds-step>
+          <ds-step step="3" icon-src="images/icon_step3.png">
+            <p slot="content">
+              매주 스터디 멤버들끼리
+              <ds-step-text-link link="https://discord.com/invite/6TwzdnW6ze">
+                디스코드
+              </ds-step-text-link>
+              에서 간단한 모임을 가져요. 멤버 간의 친밀감도 쌓고 해외 취업
+              관련한 유용한 정보도 공유하고 있어요.
+            </p>
+          </ds-step>
+        </ds-step-list>
       </section>
     `;
   }

--- a/data.js
+++ b/data.js
@@ -1,0 +1,2 @@
+export const APPLICATION_URL =
+  "https://github.com/DaleStudy/leetcode-study/discussions/209";

--- a/index.html
+++ b/index.html
@@ -188,45 +188,7 @@
       </ds-participant-review-list>
     </ds-participant-reviews-section>
 
-    <ds-steps-section id="steps-section">
-      <ds-hero>스터디 참여방법</ds-hero>
-      <ds-step-list>
-        <ds-step step="1" icon-src="images/icon_step1.png">
-          <p slot="content">
-            현재 스터디 1기(2024년 4/21~8/10)가 진행중이에요. 8/11에 시작하는
-            다음 기수 스터디 참여를 원한다면
-            <ds-step-text-link
-              link="https://github.com/DaleStudy/leetcode-study/discussions/209"
-            >
-              여기
-            </ds-step-text-link>
-            에서 신청할 수 있어요.
-          </p>
-        </ds-step>
-        <ds-step step="2" icon-src="images/icon_step2.png">
-          <p slot="content">
-            답안 제출과 확인은 깃허브를 통해 이루어져요. 스터디 전체 진행상황을
-            알고 싶다면
-            <ds-step-text-link
-              link="https://github.com/orgs/DaleStudy/projects/1"
-            >
-              프로젝트 보드
-            </ds-step-text-link>
-            를 통해 파악할 수 있어요.
-          </p>
-        </ds-step>
-        <ds-step step="3" icon-src="images/icon_step3.png">
-          <p slot="content">
-            매주 스터디 멤버들끼리
-            <ds-step-text-link link="https://discord.com/invite/6TwzdnW6ze">
-              디스코드
-            </ds-step-text-link>
-            에서 간단한 모임을 가져요. 멤버 간의 친밀감도 쌓고 해외 취업 관련한
-            유용한 정보도 공유하고 있어요.
-          </p>
-        </ds-step>
-      </ds-step-list>
-    </ds-steps-section>
+    <ds-steps-section id="steps-section"></ds-steps-section>
 
     <ds-footer>
       <ds-footer-link-list slot="footer-link-list"></ds-footer-link-list>


### PR DESCRIPTION
<!--
Describe your changes in detail using screenshots, videos, or other supporting materials. Keep in mind that pull requests serve not only to merge your code but also as valuable technical documentation and learning resources for the current and future team members.
-->

PR #186 에서 제가 스터디 2기 모집을 위해서 Steps 섹션에 있는 스터디 신청 URL을 수정했었는데요. 알고보니 Footer에도 스터디 신청 링크가 있었는데 제가 실수록 수정을 빼먹었더라고요. 2기 신청자 분께서 알려주셔서 뒤늦게 발견하게 되었습니다.

예전에 디스코드 URL도 그렇고 저는 비슷한 문제가 계속 반복되고 있는 이유가 HTML 마크업 안에 데이터를 하드코딩해놔서 그런 것 같습니다. 근본적인 해결책은 이렇게 여러 곳에 위치하는데 주기적으로 갱신이 되야하는 데이터는 한 곳에서 관리하는 것(Single Source of Truth)이라고 생각합니다.

우리 프로젝트는 백앤드나 데이터베이스가 없기 때문에 `data.js` 파일에 스터디 신청 URL을 저장해놓고 import를 하려고 했는데요. 뜻밖에 걸림돌에 부딪히게 되었습니다. 다음 두 개의 컴포넌트의 API 설계가 일관적이지 않기 때문입니다.

- `<ds-steps-section>` 요소는 slot을 통해서 외부에서 내용을 넘기도록 되어 있습니다.
- `<footer-link-list>` 요소는 slot을 받지 않고 내부적으로 내용을 랜더링하도록 되어 있습니다.

`<footer-link-list>` 요소의 내용은 자바스크립트 파일(footer-link-list.js)에 있기 때문에, 스터디 신청 URL을 import하는데 아무 문제가 없었습니다. 하지만 `<ds-steps-section>` 요소는 내용은 index.html 파일에 있기 때문에, 스터디 신청 URL을 어떻게 주입해야 할지 고민이 되었습니다.

그래서 임시 방편으로 index.html 파일에 있는 `<ds-steps-section>` 요소는 내용을 `step-section.js` 파일로 옮겨서 이 문제를 해결하였는데, 이러한 설계 변경에 대해서 어떻게 생각하시는지 다른 분들의 의견을 듣고 싶습니다.

디스코드 URL도 같이 `data.js` 파일에 저장하려고 했더니, 비슷한 문제에 부딪히게 되었습니다. `<ds-header>` 요소는 내주적으로 내용을 랜더링하는데, `<ds-intro-section>` 요소는 index.html에서 내용을 작성하여 slot을 통해 넘기도록 설계되어 있습니다.

우리 예전에 이 부분에 대해서 잠깐 논의했던 것 같은데, 컴포넌트 API를 설계할 때 언제 slot을 써야하고, 언제 쓰지 말아야 할지에 대해서 좀 더 깊이 생각해보면 어떨까요? 웹 컴포넌트가 아니라 React 컴포넌트였더라도 동일하게 API 설계을 하셨을지 생각해보시면 좋을 것 같습니다.

## Checklist before merging

- [x] Link an issue with the pull request
- [x] Ensure no errors or warnings on the browser console
- [x] Avoid additional major pushes after approval (if necessary, request a new review)
