### PR TITLE
디스코드 링크에 단축 URL 사용

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,4 +40,4 @@ We manage our project using GitHub Projects. You can find the project [here](htt
 
 ## Community
 
-- Join our [Discord](https://discord.gg/6TwzdnW6ze) to connect with other contributors.
+- Join our [Discord](https://dales.link/discord) to connect with other contributors.

--- a/components/participant-review-section.js
+++ b/components/participant-review-section.js
@@ -33,7 +33,7 @@ class ParticipantReviewsSection extends HTMLElement {
   createHtml() {
     return html`
       <section>
-        <ds-hero>참가자 후기</ds-hero>
+        <ds-hero>참여자 후기</ds-hero>
         <ds-participant-review-list>
           <ds-participant-review
             author-img-src="images/participant_1.jpeg"

--- a/data.js
+++ b/data.js
@@ -1,6 +1,6 @@
 export const APPLICATION_URL =
   "https://github.com/DaleStudy/leetcode-study/discussions/209";
-export const DISCORD_URL = "https://discord.gg/6TwzdnW6ze";
+export const DISCORD_URL = "https://dales.link/discord";
 export const PROJECT_URL = "https://github.com/orgs/DaleStudy/projects/3";
 export const CONTRIBUTING_URL =
   "https://github.com/DaleStudy/leetcode-study/blob/main/CONTRIBUTING.md";


### PR DESCRIPTION
디스코드 초대 링크에 대한 단축 URL을 만들었습니다: https://dales.link/discord 
디스코드 초대 링크는 새로 생성할 때 URL내 해시값이 바뀌는데요. 그래서 일일이 찾아서 업데이트해주는 게 번거롭고 놓치기도 쉽습니다. 단축 URL을 사용하면 이러한 문제를 쉽게 예방할 수 있습니다. 단순히 단축 URL이 가리키는 디스코드 초대 링크만 바꿔주면 되니까요.